### PR TITLE
Bug fix on debug mode false

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "cubes-doo/my-dhl",
+    "name": "santukon/my-dhl",
     "description": "Unofficial SDK for the MyDHL API",
     "type": "library",
     "autoload": {

--- a/src/MyDhl.php
+++ b/src/MyDhl.php
@@ -34,7 +34,7 @@ class MyDhl
                 $this->password
             );
 
-        $options = null;
+        $options = [];
         if ($this->debug) {
             $options = [
                 'trace' => 1,


### PR DESCRIPTION
Somehow when sending null options, it returns an error. With empty array as default works.

local.ERROR: SoapClient::__construct(): Argument #2 ($options) must be of type array, null given {"userId":2,"exception":"[object] (TypeError(code: 0): SoapClient::__construct(): Argument #2 ($options) must be of type array, null given at \\vendor\\cubes-doo\\my-dhl\\src\\MyDhl.php:45